### PR TITLE
Use `-x` to avoid partial matching

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
   - name: Check Permissions
     run: |
-      if ! grep -q "${{ inputs.actor }}" "${{ inputs.permissions-file }}"; then
+      if ! grep -qx "${{ inputs.actor }}" "${{ inputs.permissions-file }}"; then
         echo "-----------------ERROR--------------------"
         echo "User ${{ inputs.actor }} is not allowed to trigger this workflow."
         echo "------------------------------------------"


### PR DESCRIPTION
`-x` ensures that the entire line is matched exactly.

For example, if a user in `allowed_users` is `Sabit` and someone created an account with the username `abit`, the current implementation could mistakenly allow `abit` because it partially matches `Sabit`. Using the `-x` option ensures that the entire line is matched exactly, preventing partial matches from succeeding.

Here's a sample code that can be used to test:

```
#!/bin/bash
# test_rbac.sh
# Variables (simulate GitHub Action inputs)
permissions_file="permissions.yml"
actor="abit" # Replace with the actual username you want to test

# Simulated RBAC check
if ! grep -q "$actor" "$permissions_file"; then
  echo "-----------------ERROR--------------------"
  echo "User $actor is not allowed to trigger this workflow."
  echo "------------------------------------------"
  exit 1
else
  echo "User $actor is allowed to trigger this workflow."
fi
```
```
allowed_user1
allowed_user2
Sabit
```

